### PR TITLE
Use the right versions

### DIFF
--- a/org.blender.Blender.appdata.xml
+++ b/org.blender.Blender.appdata.xml
@@ -40,12 +40,12 @@
         </screenshot>
     </screenshots>
     <releases>
-        <release version="2.79.b" date="2018-03-23">
+        <release version="2.79b" date="2018-03-23">
             <description>
                 <p>This is a maintenance release fixing many bugs.</p>
             </description>
         </release>
-        <release version="2.79.a" date="2018-02-27">
+        <release version="2.79a" date="2018-02-27">
             <description>
                 <p>This is a maintenance release fixing over 200 bugs.</p>
             </description>


### PR DESCRIPTION
Due to a bug in appstream-glib, we had to mangle the versions a bit:

https://github.com/hughsie/appstream-glib/issues/231

The Freedesktop Sdk was recently updated with a fixed version of
appstream-glib :

https://github.com/flatpak/freedesktop-sdk-images/pull/96

As a result, we can now use the correct upstream versions.