### PR TITLE
Build opensubdiv

### DIFF
--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -203,6 +203,30 @@
             ]
         },
         {
+            "name": "opensubdiv",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DGLEW_LOCATION=/app",
+                "-DNO_EXAMPLES=1",
+                "-DNO_TUTORIALS=1",
+                "-DNO_PTEX=1",
+                "-DNO_DOC=1"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/PixarAnimationStudios/OpenSubdiv.git",
+                    "branch": "v3_3_3"
+                }
+            ],
+            "cleanup": [
+                "/include",
+                "/bin",
+                "/share"
+            ]
+        },
+        {
             "name": "x264",
             "config-opts": [
                 "--enable-shared",

--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -207,6 +207,7 @@
             "buildsystem": "cmake-ninja",
             "builddir": true,
             "config-opts": [
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
                 "-DGLEW_LOCATION=/app",
                 "-DNO_EXAMPLES=1",
                 "-DNO_TUTORIALS=1",
@@ -215,9 +216,9 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/PixarAnimationStudios/OpenSubdiv.git",
-                    "branch": "v3_3_3"
+                    "type": "archive",
+                    "url": "https://github.com/PixarAnimationStudios/OpenSubdiv/archive/v3_3_3.tar.gz",
+                    "sha256": "2dc81b3a085e692cca3166ac88751e4674a9ddf5b5d7935adf677bb2bd3f2d2f"
                 }
             ],
             "cleanup": [


### PR DESCRIPTION
The subsurf and multires modifiers appeared to not function with the beta version, which do work with these changes. The discussion at [1] suggests opensubdiv is missing from the build.

While `WITH_OPENSUBDIV` is indeed set in the `config-opts` of blender in the build manifest, I believe it is ignored due to similar reasons discussed by @bochecha here[2].

[1] https://developer.blender.org/T62693
[2] https://github.com/flathub/org.blender.Blender/issues/3#issuecomment-366451031