### PR TITLE
Remove fftw

### DIFF
--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -324,41 +324,6 @@
             ]
         },
         {
-            "name": "fftw",
-            "build-options" : {
-                "arch" : {
-                    "x86_64" : {
-                        "config-opts" : [
-                            "--enable-sse2",
-                            "--enable-avx"
-                        ]
-                    }
-                }
-            },
-            "config-opts": [
-                "--enable-shared",
-                "--enable-threads",
-                "--enable-openmp"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "http://www.fftw.org/fftw-3.3.8.tar.gz",
-                    "sha256": "6113262f6e92c5bd474f2875fa1b01054c4ad5040f6b0da7c03c98821d9ae303"
-                }
-            ],
-            "cleanup": [
-                "/bin",
-                "/include",
-                "/lib/*.a",
-                "/lib/*.la",
-                "/lib/cmake",
-                "/lib/pkgconfig",
-                "/share/info",
-                "/share/man"
-            ]
-        },
-        {
             "name": "opencollada",
             "buildsystem": "cmake-ninja",
             "builddir": true,


### PR DESCRIPTION
We originally had to bundle it because the Freedesktop SDK 1.6 didn't have it.

However, the Freedesktop SDK 18.08 has it, so we don't need to build it ourselves any more.