### PR TITLE
Use the platform ffmpeg

### DIFF
--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -14,6 +14,16 @@
         "--share=network",
         "--filesystem=host"
     ],
+    "add-extensions": {
+        "org.freedesktop.Platform.ffmpeg-full": {
+            "directory": "lib/ffmpeg",
+            "version": "19.08",
+            "add-ld-path": "."
+        }
+    },
+    "cleanup-commands": [
+        "mkdir -p /app/lib/ffmpeg"
+    ],
     "modules": [
         "shared-modules/glu/glu-9.json",
         "shared-modules/glew/glew.json",
@@ -361,102 +371,6 @@
                 "/lib/*.a",
                 "/lib/cmake",
                 "/share/doc"
-            ]
-        },
-        {
-            "name": "x264",
-            "config-opts": [
-                "--enable-shared",
-                "--disable-cli"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "http://ftp.videolan.org/pub/x264/snapshots/x264-snapshot-20191124-2245-stable.tar.bz2",
-                    "sha256": "1916a76a29c2d2c177a5f6fbf5c84f4b18326ef3babb2795215f7a5a2a801ff7"
-                }
-            ],
-            "cleanup": [
-                "/include",
-                "/lib/pkgconfig"
-            ]
-        },
-        {
-            "name": "ffmpeg",
-            "config-opts": [
-                "--enable-shared",
-                "--disable-static",
-                "--disable-doc",
-                "--enable-gpl",
-                "--enable-version3",
-                "--disable-nonfree",
-                "--enable-optimizations",
-                "--enable-pthreads",
-
-                "--disable-bzlib",
-                "--disable-libgsm",
-                "--enable-libtheora",
-                "--enable-libvorbis",
-                "--enable-libvpx",
-                "--enable-libx264",
-                "--enable-zlib",
-                "--disable-libxcb",
-                "--disable-lzma",
-
-                "--disable-programs",
-                "--disable-network",
-
-                "--disable-protocols",
-                "--enable-protocol=file",
-
-                "--disable-devices",
-
-                "--enable-muxer=avi",
-                "--enable-muxer=h264",
-                "--enable-muxer=mov",
-                "--enable-muxer=mp4",
-                "--enable-muxer=ogg",
-                "--enable-muxer=webm",
-
-                "--enable-demuxer=avi",
-                "--enable-demuxer=h264",
-                "--enable-demuxer=mov",
-                "--enable-demuxer=mp3",
-                "--enable-demuxer=ogg",
-                "--enable-demuxer=wav",
-
-                "--enable-parser=h264",
-                "--enable-parser=vorbis",
-
-                "--enable-encoder=aac",
-                "--enable-encoder=libtheora",
-                "--enable-encoder=libvorbis",
-                "--enable-encoder=libvpx_vp8",
-                "--enable-encoder=libvpx_vp9",
-                "--enable-encoder=libx264",
-                "--enable-encoder=mpeg4",
-
-                "--enable-decoder=aac",
-                "--enable-decoder=h264",
-                "--enable-decoder=libvorbis",
-                "--enable-decoder=libvpx_vp8",
-                "--enable-decoder=libvpx_vp9",
-                "--enable-decoder=mp3",
-                "--enable-decoder=mpeg4",
-                "--enable-decoder=pcm_s16le",
-                "--enable-decoder=theora"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://www.ffmpeg.org/releases/ffmpeg-4.0.5.tar.xz",
-                    "sha256": "13f258aa54e181cb3c49e35c12ab842f05e3b1d1588100567b2e53ebb0ef3972"
-                }
-            ],
-            "cleanup": [
-                "/include",
-                "/lib/pkgconfig",
-                "/share/ffmpeg"
             ]
         },
         {


### PR DESCRIPTION
I've been bundling ffmpeg because of its reputation for API/ABI
instability, and to make sure the needed codecs were available.

Upstream ffmpeg apparently improved dramatically on this over the past
few years, to the point where we should look into using the platform
version.

The Freedesktop platform now provides a limited ffmpeg which doesn't
include all the codecs Blender can use, but it also provides an
extension with a full ffmpeg.

This allows distributors to preinstall Blender and the platform without
the nonfree/patented codecs, and users can choose to add the extension
later on.

Fixes #39