### PR TITLE
Introduce the org.blender.Blender.Codecs extension

### DIFF
--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -15,6 +15,12 @@
         "--filesystem=host"
     ],
     "add-extensions": {
+        "org.blender.Blender.Codecs": {
+            "directory": "lib/codecs",
+            "add-ld-path": "lib",
+            "bundle" : true,
+            "autodelete" : true
+        },
         "org.freedesktop.Platform.ffmpeg-full": {
             "directory": "lib/ffmpeg",
             "version": "19.08",
@@ -352,6 +358,7 @@
         {
             "name": "x264",
             "config-opts": [
+                "--prefix=/app/lib/codecs",
                 "--enable-shared",
                 "--disable-cli"
             ],
@@ -363,13 +370,20 @@
                 }
             ],
             "cleanup": [
-                "/include",
-                "/lib/pkgconfig"
+                "/lib/codecs/include",
+                "/lib/codecs/lib/pkgconfig"
             ]
         },
         {
             "name": "ffmpeg",
+            "build-options" : {
+                "env": {
+                    "PKG_CONFIG_PATH": "/app/lib/codecs/lib/pkgconfig"
+                }
+            },
             "config-opts": [
+                "--prefix=/app/lib/codecs",
+
                 "--enable-shared",
                 "--disable-static",
                 "--disable-doc",
@@ -440,9 +454,9 @@
                 }
             ],
             "cleanup": [
-                "/include",
-                "/lib/pkgconfig",
-                "/share/ffmpeg"
+                "/lib/codecs/include",
+                "/lib/codecs/lib/pkgconfig",
+                "/lib/codecs/share"
             ]
         },
         {

--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -358,8 +358,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://ftp.videolan.org/pub/x264/snapshots/x264-snapshot-20191124-2245-stable.tar.bz2",
-                    "sha256": "1916a76a29c2d2c177a5f6fbf5c84f4b18326ef3babb2795215f7a5a2a801ff7"
+                    "url": "http://ftp.videolan.org/pub/x264/snapshots/x264-snapshot-20191217-2245-stable.tar.bz2",
+                    "sha256": "b2495c8f2930167d470994b1ce02b0f4bfb24b3317ba36ba7f112e9809264160"
                 }
             ],
             "cleanup": [

--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -350,6 +350,102 @@
             ]
         },
         {
+            "name": "x264",
+            "config-opts": [
+                "--enable-shared",
+                "--disable-cli"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.videolan.org/pub/x264/snapshots/x264-snapshot-20191124-2245-stable.tar.bz2",
+                    "sha256": "1916a76a29c2d2c177a5f6fbf5c84f4b18326ef3babb2795215f7a5a2a801ff7"
+                }
+            ],
+            "cleanup": [
+                "/include",
+                "/lib/pkgconfig"
+            ]
+        },
+        {
+            "name": "ffmpeg",
+            "config-opts": [
+                "--enable-shared",
+                "--disable-static",
+                "--disable-doc",
+                "--enable-gpl",
+                "--enable-version3",
+                "--disable-nonfree",
+                "--enable-optimizations",
+                "--enable-pthreads",
+
+                "--disable-bzlib",
+                "--disable-libgsm",
+                "--enable-libtheora",
+                "--enable-libvorbis",
+                "--enable-libvpx",
+                "--enable-libx264",
+                "--enable-zlib",
+                "--disable-libxcb",
+                "--disable-lzma",
+
+                "--disable-programs",
+                "--disable-network",
+
+                "--disable-protocols",
+                "--enable-protocol=file",
+
+                "--disable-devices",
+
+                "--enable-muxer=avi",
+                "--enable-muxer=h264",
+                "--enable-muxer=mov",
+                "--enable-muxer=mp4",
+                "--enable-muxer=ogg",
+                "--enable-muxer=webm",
+
+                "--enable-demuxer=avi",
+                "--enable-demuxer=h264",
+                "--enable-demuxer=mov",
+                "--enable-demuxer=mp3",
+                "--enable-demuxer=ogg",
+                "--enable-demuxer=wav",
+
+                "--enable-parser=h264",
+                "--enable-parser=vorbis",
+
+                "--enable-encoder=aac",
+                "--enable-encoder=libtheora",
+                "--enable-encoder=libvorbis",
+                "--enable-encoder=libvpx_vp8",
+                "--enable-encoder=libvpx_vp9",
+                "--enable-encoder=libx264",
+                "--enable-encoder=mpeg4",
+
+                "--enable-decoder=aac",
+                "--enable-decoder=h264",
+                "--enable-decoder=libvorbis",
+                "--enable-decoder=libvpx_vp8",
+                "--enable-decoder=libvpx_vp9",
+                "--enable-decoder=mp3",
+                "--enable-decoder=mpeg4",
+                "--enable-decoder=pcm_s16le",
+                "--enable-decoder=theora"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://www.ffmpeg.org/releases/ffmpeg-4.0.5.tar.xz",
+                    "sha256": "13f258aa54e181cb3c49e35c12ab842f05e3b1d1588100567b2e53ebb0ef3972"
+                }
+            ],
+            "cleanup": [
+                "/include",
+                "/lib/pkgconfig",
+                "/share/ffmpeg"
+            ]
+        },
+        {
             "name": "numpy",
             "buildsystem": "simple",
             "build-commands": [


### PR DESCRIPTION
We used to bundle our own ffmpeg with all the codecs Blender needs.

But because Endless wanted to preinstall Blender on some of its images, I made it use the runtime ffmpeg instead, or the one from the `org.freedesktop.Platform.ffmpeg-full` extension if it is installed.

That runtime extension has H264 support enabled… but doesn't actually contain any H264 encoder/decoder because it requires the `org.freedesktop.Platform.openh264` extension for that.

Unfortunately, even when you have both runtime extensions installed, H264 encoding still doesn't work in Blender because the openh264 encoder is not good enough. :disappointed:

This commit adds an `org.blender.Blender.Codecs` extension which bundles the ffmpeg we used to bundle directly in Blender.

Installing it gets all encoding/decoding working again in Blender, but having it as an extension allows Endless, and other distributors, to preinstall Blender without worrying about codecs.

cc @jimmac