### PR TITLE
Update version

### DIFF
--- a/blender-appdata.patch
+++ b/blender-appdata.patch
@@ -1,11 +1,13 @@
 diff -ur blender-2.83.1_old/release/freedesktop/org.blender.Blender.appdata.xml blender-2.83.1/release/freedesktop/org.blender.Blender.appdata.xml
 --- blender-2.83.1_old/release/freedesktop/org.blender.Blender.appdata.xml	2020-06-12 12:11:11.000000000 +0200
 +++ blender-2.83.1/release/freedesktop/org.blender.Blender.appdata.xml	2020-06-26 13:00:34.217546077 +0200
-@@ -39,6 +39,7 @@
+@@ -39,6 +39,9 @@
              <image>https://download.blender.org/demo/screenshots/blender_screenshot_4.jpg</image>
          </screenshot>
      </screenshots>
 +    <content_rating type="oars-1.1"/>
      <releases>
++        <release version="2.83.2" date="2020-07-09" />
++        <release version="2.83.1" date="2020-06-25" />
          <release version="2.83" date="2020-06-03">
              <description>


### PR DESCRIPTION
The version was not updated and made users think Flathub didn't have the latest:

https://fortwire.github.io/Who-Updates/

This also impact the display on Flathub.org.