### PR TITLE
Fix command line arguments

### DIFF
--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -175,7 +175,7 @@
                     "type": "script",
                     "commands": [
                         "cd /app/blender",
-                        "exec ./blender"
+                        "exec ./blender \"$@\""
                     ],
                     "dest-filename": "blender.sh"
                 }


### PR DESCRIPTION
propagate all arguments passed to blender, this is convenient
when using blender without a user interface (Such as when
you are forced to ssh into your workstation because your
friend tested positive and you've been quarantined for the
next couple weeks)