### PR TITLE
Workaround for hardcoded paths in recent blender.desktop patch

### DIFF
--- a/blender-desktop-add-wm-class.patch
+++ b/blender-desktop-add-wm-class.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add StartupWMClass to .desktop
  blender.desktop | 1 +
  1 file changed, 1 insertion(+)
 
-diff --git a/blender-3.0.0-linux-x64/blender.desktop b/blender-3.0.0-linux-x64/blender.desktop
+diff --git a/blender/blender.desktop b/blender/blender.desktop
 index 792f98b..b9d74d9 100644
---- a/blender-3.0.0-linux-x64/blender.desktop
-+++ b/blender-3.0.0-linux-x64/blender.desktop
+--- a/blender/blender.desktop
++++ b/blender/blender.desktop
 @@ -87,3 +87,4 @@ PrefersNonDefaultGPU=true
  X-KDE-RunOnDiscreteGpu=true
  Categories=Graphics;3DGraphics;

--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -130,7 +130,7 @@
             "buildsystem": "simple",
             "build-commands": [
                 "install -Dm755 blender.sh /app/bin/blender",
-                "mv blender*linux* /app/blender",
+                "mv blender /app/blender",
                 "install -Dm644 /app/blender/blender.desktop /app/share/applications/$FLATPAK_ID.desktop",
                 "desktop-file-edit --set-icon=${FLATPAK_ID} /app/share/applications/${FLATPAK_ID}.desktop",
                 "install -Dm644 /app/blender/blender.svg /app/share/icons/hicolor/scalable/apps/$FLATPAK_ID.svg",
@@ -150,6 +150,10 @@
                         "stable-only": true,
                         "url-template": "https://ftp.nluug.nl/pub/graphics/blender/release/Blender$major.$minor/blender-$version-linux-x64.tar.xz"
                     }
+                },
+                {
+                    "type": "shell",
+                    "commands": ["mv blender*linux* blender"]
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
Fixes building of newer blender versions. Closes #93