### PR TITLE
Update Dependencies

### DIFF
--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -44,7 +44,8 @@
                 {
                     "type": "git",
                     "url": "https://code.videolan.org/videolan/x264.git",
-                    "commit": "bfc87b7a330f75f5c9a21e56081e4b20344f139e"
+                    "branch": "stable",
+                    "commit": "baee400fa9ced6f5481a728138fed6e867b0ff7f"
                 }
             ],
             "cleanup": [
@@ -117,8 +118,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://www.ffmpeg.org/releases/ffmpeg-4.4.1.tar.xz",
-                    "sha256": "eadbad9e9ab30b25f5520fbfde99fae4a92a1ae3c0257a8d68569a4651e30e02"
+                    "url": "https://www.ffmpeg.org/releases/ffmpeg-5.0.1.tar.xz",
+                    "sha256": "ef2efae259ce80a240de48ec85ecb062cecca26e4352ffb3fda562c21a93007b"
                 }
             ],
             "cleanup": [


### PR DESCRIPTION
Updates ffmpeg and x264.

Also updates shared-modules. Since it doesn't seem to be used in the current manifest, should it be considered for removal?