### PR TITLE
Update Runtime to 22.08, Blender to 3.4 and enable Wayland

### DIFF
--- a/org.blender.Blender.appdata.xml
+++ b/org.blender.Blender.appdata.xml
@@ -41,6 +41,7 @@
     </screenshots>
     <content_rating type="oars-1.1"/>
     <releases>
+        <release version="3.4.0" date="2022-12-07"/>
         <release version="3.3.1" date="2022-10-05"/>
         <release version="3.3.0" date="2022-09-07"/>
         <release version="3.2.2" date="2022-08-03"/>

--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -32,6 +32,7 @@
         "mkdir -p /app/lib/ffmpeg"
     ],
     "modules": [
+        "shared-modules/libdecor/libdecor-0.1.1.json",
         {
             "name": "x264",
             "config-opts": [
@@ -126,23 +127,6 @@
                 "/lib/codecs/include",
                 "/lib/codecs/lib/pkgconfig",
                 "/lib/codecs/share"
-            ]
-        },
-        {
-            "name": "libdecor",
-            "buildsystem": "meson",
-            "build-options": {
-                "config-opts": [
-                    "-Ddemo=false"
-                ]
-            },
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/jadahl/libdecor.git",
-                    "commit": "4db201134ab51950a1c673d77d7c4f2f7c7b48fd",
-                    "tag": "0.1.1"
-                }
             ]
         },
         {

--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -129,6 +129,23 @@
             ]
         },
         {
+            "name": "libdecor",
+            "buildsystem": "meson",
+            "build-options": {
+                "config-opts": [
+                    "-Ddemo=false"
+                ]
+            },
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/jadahl/libdecor.git",
+                    "commit": "4db201134ab51950a1c673d77d7c4f2f7c7b48fd",
+                    "tag": "0.1.1"
+                }
+            ]
+        },
+        {
             "name": "blender",
             "buildsystem": "simple",
             "build-commands": [

--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -1,12 +1,13 @@
 {
     "id": "org.blender.Blender",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "21.08",
+    "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "blender",
     "finish-args": [
         "--share=ipc",
-        "--socket=x11",
+        "--socket=wayland",
+        "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--device=dri",
         "--share=network",
@@ -23,7 +24,7 @@
         },
         "org.freedesktop.Platform.ffmpeg-full": {
             "directory": "lib/ffmpeg",
-            "version": "21.08",
+            "version": "22.08",
             "add-ld-path": "."
         }
     },
@@ -143,8 +144,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://ftp.nluug.nl/pub/graphics/blender/release/Blender3.3/blender-3.3.1-linux-x64.tar.xz",
-                    "sha256": "3089a485dd621785d7a702089aba72d07b8f733a362e901ec1449b9a379546f2",
+                    "url": "https://ftp.nluug.nl/pub/graphics/blender/release/Blender3.4/blender-3.4.0-linux-x64.tar.xz",
+                    "sha256": "f9aaf69339e4aad3b7927a4cf7ba372453e393df662c92bc1fedf94e0c6b5382",
                     "strip-components": 0,
                     "x-checker-data": {
                         "type": "anitya",


### PR DESCRIPTION
Blender 3.4 is out and officially supports Wayland. For GNOME this requires libdecor to have a titlebar since GNOME does not support server side decoration. See https://code.blender.org/2022/10/wayland-support-on-linux/ for more details.

I also updated the runtime to 22.08 to have more up-to-date Mesa drivers.

It is "works for me" in Sway and GNOME.

fixes https://github.com/flathub/org.blender.Blender/issues/125