### PR TITLE
(Closed, restricted to verified apps) Automatically merge flathubbot updates & Update to 4.2

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-  "only-arches": ["x86_64"]
+  "only-arches": ["x86_64"],
+  "automerge-flathubbot-prs": true
 }

--- a/org.blender.Blender.appdata.xml
+++ b/org.blender.Blender.appdata.xml
@@ -42,6 +42,9 @@
     </screenshots>
     <content_rating type="oars-1.1"/>
     <releases>
+        <release version="4.2.0" date="2024-07-16">
+            <description></description>
+        </release>
         <release version="4.1.1" date="2024-04-16"/>
         <release version="4.1.0" date="2024-03-26">
             <description>

--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -163,8 +163,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://ftp.nluug.nl/pub/graphics/blender/release/Blender4.1/blender-4.1.1-linux-x64.tar.xz",
-                    "sha256": "ab2ea3fe991601a5e6bd2cda786ecaa919c0b39e0550e59978b5d40270c260d3",
+                    "url": "https://ftp.nluug.nl/pub/graphics/blender/release/Blender4.2/blender-4.2.0-linux-x64.tar.xz",
+                    "sha256": "4f4fd7646af01f6fee9d420408318381a6e52571268eb7cf9cd5033bd9e7a359",
                     "strip-components": 0,
                     "x-checker-data": {
                         "type": "anitya",


### PR DESCRIPTION
This way it can push faster, given how exciting the Blender releases are!
Also includes #182