### PR TITLE
Update Blender, Runtime, FFMPEG

### DIFF
--- a/org.blender.Blender.appdata.xml
+++ b/org.blender.Blender.appdata.xml
@@ -42,9 +42,9 @@
     </screenshots>
     <content_rating type="oars-1.1"/>
     <releases>
-        <release version="4.2.3" date="2024-10-15">
-        <release version="4.2.2" date="2024-09-24">
-        <release version="4.2.1" date="2024-08-20">
+        <release version="4.2.3" date="2024-10-15"/>
+        <release version="4.2.2" date="2024-09-24"/>
+        <release version="4.2.1" date="2024-08-20"/>
         <release version="4.2.0" date="2024-07-16">
             <description>
                 <p>Enhancements:</p>

--- a/org.blender.Blender.appdata.xml
+++ b/org.blender.Blender.appdata.xml
@@ -42,12 +42,9 @@
     </screenshots>
     <content_rating type="oars-1.1"/>
     <releases>
+        <release version="4.2.3" date="2024-10-15">
         <release version="4.2.2" date="2024-09-24">
-            <description></description>
-        </release>
         <release version="4.2.1" date="2024-08-20">
-            <description/>
-        </release>
         <release version="4.2.0" date="2024-07-16">
             <description>
                 <p>Enhancements:</p>

--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -122,8 +122,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://www.ffmpeg.org/releases/ffmpeg-6.1.1.tar.xz",
-                    "sha256": "8684f4b00f94b85461884c3719382f1261f0d9eb3d59640a1f4ac0873616f968"
+                    "url": "https://www.ffmpeg.org/releases/ffmpeg-7.1.tar.xz",
+                    "sha256": "40973d44970dbc83ef302b0609f2e74982be2d85916dd2ee7472d30678a7abe6"
                 }
             ],
             "cleanup": [

--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -1,7 +1,7 @@
 {
     "id": "org.blender.Blender",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "23.08",
+    "runtime-version": "24.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "blender",
     "finish-args": [
@@ -27,7 +27,7 @@
         },
         "org.freedesktop.Platform.ffmpeg-full": {
             "directory": "lib/ffmpeg",
-            "version": "23.08",
+            "version": "24.08",
             "add-ld-path": "."
         }
     },
@@ -163,8 +163,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://ftp.nluug.nl/pub/graphics/blender/release/Blender4.2/blender-4.2.2-linux-x64.tar.xz",
-                    "sha256": "443c5fcbb929a54afad339c8f445b2620b00c2be173d68158ccb4f62f81ca9d7",
+                    "url": "https://ftp.nluug.nl/pub/graphics/blender/release/Blender4.2/blender-4.2.3-linux-x64.tar.xz",
+                    "sha256": "3a64efd1982465395abab4259b4091d5c8c56054c7267e9633e4f702a71ea3f4",
                     "strip-components": 0,
                     "x-checker-data": {
                         "type": "anitya",


### PR DESCRIPTION
Update FFMPEG because version 6.1.1 failed, maybe relate to https://github.com/jc-kynesim/rpi-ffmpeg/issues/87
Update Blender
Cleanup appdata