### PR TITLE
Update blender and runtime

### DIFF
--- a/org.blender.Blender.appdata.xml
+++ b/org.blender.Blender.appdata.xml
@@ -42,6 +42,9 @@
     </screenshots>
     <content_rating type="oars-1.1"/>
     <releases>
+        <release version="4.2.3" date="2024-10-15">
+            <url type="details">https://www.blender.org/download/lts/4-2/</url>
+        </release>
         <release version="4.2.2" date="2024-09-24">
             <description></description>
         </release>

--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -1,7 +1,7 @@
 {
     "id": "org.blender.Blender",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "23.08",
+    "runtime-version": "24.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "blender",
     "finish-args": [
@@ -122,8 +122,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://www.ffmpeg.org/releases/ffmpeg-6.1.1.tar.xz",
-                    "sha256": "8684f4b00f94b85461884c3719382f1261f0d9eb3d59640a1f4ac0873616f968"
+                    "url": "https://www.ffmpeg.org/releases/ffmpeg-6.1.2.tar.xz",
+                    "sha256": "3b624649725ecdc565c903ca6643d41f33bd49239922e45c9b1442c63dca4e38"
                 }
             ],
             "cleanup": [

--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -163,8 +163,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://ftp.nluug.nl/pub/graphics/blender/release/Blender4.2/blender-4.2.2-linux-x64.tar.xz",
-                    "sha256": "443c5fcbb929a54afad339c8f445b2620b00c2be173d68158ccb4f62f81ca9d7",
+                    "url": "https://ftp.nluug.nl/pub/graphics/blender/release/Blender4.2/blender-4.2.3-linux-x64.tar.xz",
+                    "sha256": "3a64efd1982465395abab4259b4091d5c8c56054c7267e9633e4f702a71ea3f4",
                     "strip-components": 0,
                     "x-checker-data": {
                         "type": "anitya",

--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -158,7 +158,7 @@
                 "install -Dm644 /app/blender/blender.svg /app/share/icons/hicolor/scalable/apps/$FLATPAK_ID.svg",
                 "install -Dm644 /app/blender/blender-symbolic.svg /app/share/icons/hicolor/symbolic/apps/$FLATPAK_ID-symbolic.svg",
                 "cd /app/blender/*.*/datafiles && mv locale /app/share/locale && ln -sf /app/share/locale locale",
-                "install -Dm644 $FLATPAK_ID.appdata.xml /app/share/metainfo/$FLATPAK_ID.metainfo.xml"
+                "install -Dm644 $FLATPAK_ID.metainfo.xml /app/share/metainfo/$FLATPAK_ID.metainfo.xml"
             ],
             "sources": [
                 {
@@ -181,7 +181,7 @@
                 },
                 {
                     "type": "file",
-                    "path": "org.blender.Blender.appdata.xml"
+                    "path": "org.blender.Blender.metainfo.xml"
                 },
                 {
                     "type": "script",

--- a/org.blender.Blender.metainfo.xml
+++ b/org.blender.Blender.metainfo.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="desktop">
+<component type="desktop-application">
     <id>org.blender.Blender</id>
-    <launchable type="desktop-id">org.blender.Blender.desktop</launchable>
-    <name>Blender</name>
-    <developer_name>Blender Foundation</developer_name>
-    <summary>Free and open source 3D creation suite</summary>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-3.0</project_license>
+    <name>Blender</name>
+    <summary>Free and open source 3D creation suite</summary>
+    <developer id="org.blender">
+        <name>Blender Foundation</name>
+    </developer>
     <description>
         <p>
             Blender is the free and open source 3D creation suite. It supports
@@ -22,6 +23,12 @@
             the list goes on.
         </p>
     </description>
+    <launchable type="desktop-id">org.blender.Blender.desktop</launchable>
+    <branding>
+    <color type="primary" scheme_preference="light">#eeeeee</color>
+    <color type="primary" scheme_preference="dark">#313131</color>
+    </branding>
+    <content_rating type="oars-1.1"/>
     <url type="homepage">https://www.blender.org</url>
     <url type="help">https://www.blender.org/support/</url>
     <url type="bugtracker">https://developer.blender.org</url>
@@ -40,17 +47,12 @@
             <image>https://download.blender.org/demo/screenshots/blender_screenshot_4.jpg</image>
         </screenshot>
     </screenshots>
-    <content_rating type="oars-1.1"/>
     <releases>
         <release version="4.2.3" date="2024-10-15">
             <url type="details">https://www.blender.org/download/lts/4-2/</url>
         </release>
-        <release version="4.2.2" date="2024-09-24">
-            <description></description>
-        </release>
-        <release version="4.2.1" date="2024-08-20">
-            <description/>
-        </release>
+        <release version="4.2.2" date="2024-09-24"/>
+        <release version="4.2.1" date="2024-08-20"/>
         <release version="4.2.0" date="2024-07-16">
             <description>
                 <p>Enhancements:</p>


### PR DESCRIPTION
Follow the latest metainfo guidelines https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/
Update to latest point release
Update runtime to 24.08

Upstream doesn't support FFMPEG 7 yet, sticking with 6.x see
https://projects.blender.org/blender/blender/pulls/121947/
https://projects.blender.org/blender/blender/pulls/121960/
Could add the patch, though that might go against Flatpak's point.