### PR TITLE
MetaInfo: align to Flathub guidelines

### DIFF
--- a/org.blender.Blender.metainfo.xml
+++ b/org.blender.Blender.metainfo.xml
@@ -4,16 +4,15 @@
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-3.0</project_license>
     <name>Blender</name>
-    <summary>Free and open source 3D creation suite</summary>
+    <summary>Model, animate, rig, & more in 3D</summary>
     <developer id="org.blender">
         <name>Blender Foundation</name>
     </developer>
     <description>
         <p>
-            Blender is the free and open source 3D creation suite. It supports
-            the entirety of the 3D pipeline — modeling, rigging, animation,
-            simulation, rendering, compositing, motion tracking, and video
-            editing.
+            The free and open source 3D creation suite that supports the entirety of 
+            the 3D pipeline: modeling, rigging, animation, simulation, rendering, 
+            compositing, motion tracking, and video editing.
         </p>
 
         <p>

--- a/org.blender.Blender.metainfo.xml
+++ b/org.blender.Blender.metainfo.xml
@@ -4,7 +4,7 @@
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-3.0</project_license>
     <name>Blender</name>
-    <summary>Model, animate, rig, & more in 3D</summary>
+    <summary>Model, animate, rig, &amp; more in 3D</summary>
     <developer id="org.blender">
         <name>Blender Foundation</name>
     </developer>

--- a/org.blender.Blender.metainfo.xml
+++ b/org.blender.Blender.metainfo.xml
@@ -24,8 +24,8 @@
     </description>
     <launchable type="desktop-id">org.blender.Blender.desktop</launchable>
     <branding>
-    <color type="primary" scheme_preference="light">#eeeeee</color>
-    <color type="primary" scheme_preference="dark">#313131</color>
+      <color type="primary" scheme_preference="light">#5ab3f6</color>
+      <color type="primary" scheme_preference="dark">#265787</color>
     </branding>
     <content_rating type="oars-1.1"/>
     <url type="homepage">https://www.blender.org</url>


### PR DESCRIPTION
This changes the [summary] to something a bit shorter, more descriptive, and in the [imperative]. It also improves the [description] by avoiding repeating the summary and avoiding starting with the app name again.

It also updates the brand colors for the banner; these were taken directly from blender.org (the button highlight color for the light color, the official brand blue for the dark color):

![Screenshot 2025-03-04 at 21-17-47 Brand color preview Flathub Documentation](https://github.com/user-attachments/assets/96e87416-db39-4b9c-a56c-91809dc2ef1d)


My hope is that we can get this MetaInfo into shape to feature Blender on the Flathub homepage soon, seeing as how it's having a moment with it being used for an Academy Award winning film. :)

[summary]: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines#summary
[imperative]: https://en.wikipedia.org/wiki/Imperative_mood
[description]:https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines#description