### PR TITLE
Work around mesa issue #12444 in grease pencil

### DIFF
--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -13,6 +13,7 @@
         "--share=network",
         "--filesystem=host",
         "--filesystem=/run/spnav.sock:ro",
+        "--env=AMD_DEBUG=useaco",
         "--env=SPNAV_SOCKET=/run/spnav.sock",
         "--env=TMP_DIR=/tmp",
         "--env=TMP=/tmp",


### PR DESCRIPTION
Grease pencil anti-aliasing has caused jagged artifacts on AMD GPUs since this package was updated to 24.08.

https://projects.blender.org/blender/blender/issues/133386

https://gitlab.freedesktop.org/mesa/mesa/-/issues/12444

| before | after |
| - | - |
| ![Screenshot From 2025-03-29 14-08-54](https://github.com/user-attachments/assets/3cea044d-aa59-45a0-ad5e-2cf43c8974cc) | ![Screenshot From 2025-03-29 14-08-09](https://github.com/user-attachments/assets/f7e4be1c-e5d6-458d-b93d-cd779532ebfb) |
