### PR TITLE
blender: Update blender-4.4.3-linux-x64.tar.xz to 4.5.0

### DIFF
--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -164,8 +164,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://ftp.nluug.nl/pub/graphics/blender/release/Blender4.4/blender-4.4.3-linux-x64.tar.xz",
-                    "sha256": "8d3be07d2bc412b502c6bfe3cfe3e22195a4164076867da987ce148d73c27946",
+                    "url": "https://ftp.nluug.nl/pub/graphics/blender/release/Blender4.5/blender-4.5.0-linux-x64.tar.xz",
+                    "sha256": "1188b95cc12321c770b631939f7c25a096910b6f884a990bf9c0f62d52b38aec",
                     "strip-components": 0,
                     "x-checker-data": {
                         "type": "anitya",

--- a/org.blender.Blender.metainfo.xml
+++ b/org.blender.Blender.metainfo.xml
@@ -47,6 +47,30 @@
         </screenshot>
     </screenshots>
     <releases>
+        <release version="4.5.0" date="2025-07-15">
+            <description>
+                <p>New features:</p>
+                <ul>
+                    <li>Full Vulkan support with major improvements for performance and compatibility</li>
+                    <li>Faster startup times and multi-threaded shader compilation</li>
+                    <li>Enhanced Geometry Nodes with support for importing multiple file formats (CSV, PLY, VDB, STL, OBJ, TXT)</li>
+                    <li>New Point Cloud object type for representing large numbers of individual points in 3D space</li>
+                    <li>Improved Compositor with procedural texture nodes and common nodes from Shader and Geometry Nodes</li>
+                    <li>Grease Pencil render pass and supersampling anti-aliasing (SSAA) for better line quality</li>
+                    <li>UV visibility in all object modes, not just Edit Mode</li>
+                    <li>Enhanced Video Sequencer with HDR support and improved cache</li>
+                    <li>Shadow terminator bias in EEVEE to eliminate self-shadowing artifacts</li>
+                    <li>Color randomization in Sculpt, Vertex Paint, and Texture Paint modes</li>
+                </ul>
+                <p>Performance improvements:</p>
+                <ul>
+                    <li>Geometry Nodes attribute domain interpolation up to 7x faster</li>
+                    <li>Liquid simulation up to 1.5x faster</li>
+                    <li>Faster texture loading and optimized startup process</li>
+                    <li>Improved trimming performance in Sculpt mode with new Manifold solver</li>
+                </ul>
+            </description>
+        </release>
         <release version="4.4.3" date="2025-04-29">
             <description></description>
         </release>


### PR DESCRIPTION
This PR updates Blender Flatpak to version 4.5.0.

- Updated tarball URL to 4.5.0 official release
- Updated SHA256 checksum
- Updated version in metainfo file

Successfully built and tested locally using:
