### PR TITLE
Update Blender to 4.5.1 LTS

### DIFF
--- a/org.blender.Blender.json
+++ b/org.blender.Blender.json
@@ -176,14 +176,14 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://ftp.nluug.nl/pub/graphics/blender/release/Blender4.5/blender-4.5.0-linux-x64.tar.xz",
-                    "sha256": "1188b95cc12321c770b631939f7c25a096910b6f884a990bf9c0f62d52b38aec",
+                    "url": "https://download.blender.org/release/Blender4.5/blender-4.5.1-linux-x64.tar.xz",
+                    "sha256": "085a7ed4ed80c3cb66783bad76f236f39897de5d33884abd133e0c6db94c0f14",
                     "strip-components": 0,
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 201,
                         "stable-only": true,
-                        "url-template": "https://ftp.nluug.nl/pub/graphics/blender/release/Blender$major.$minor/blender-$version-linux-x64.tar.xz"
+                        "url-template": "https://download.blender.org/release/Blender$major.$minor/blender-$version-linux-x64.tar.xz"
                     }
                 },
                 {

--- a/org.blender.Blender.metainfo.xml
+++ b/org.blender.Blender.metainfo.xml
@@ -47,6 +47,12 @@
         </screenshot>
     </screenshots>
     <releases>
+        <release version="4.5.1" date="2025-07-29">
+            <description>
+                <p>Released on July 29th 2025, Blender 4.5.1 features 89 bug fixes.</p>
+                <p>For more details, see: <url>https://developer.blender.org/docs/release_notes/4.5/corrective_releases/#blender-451</url></p>
+            </description>
+        </release>
         <release version="4.5.0" date="2025-07-15">
             <description>
                 <p>New features:</p>


### PR DESCRIPTION
Released on July 29th 2025, Blender 4.5.1 features 89 bug fixes.
For more details, see: <https://developer.blender.org/docs/release_notes/4.5/corrective_releases/#blender-451>.

Updated manifest and metainfo.
Uses [default blender.org mirror](https://download.blender.org/release/Blender4.5/blender-4.5.1-linux-x64.tar.xz): #212 